### PR TITLE
fix: skip false positive notifications from Cursor's own AI (closes #42)

### DIFF
--- a/Scripts/notify.sh
+++ b/Scripts/notify.sh
@@ -4,14 +4,26 @@
 EVENT_TYPE="$1"
 NOTIFIER="claude-notifier"
 
-# Read hook input from stdin (Claude Code passes JSON with notification_type)
-# Skip idle_prompt — user was already notified when input was first needed
+# Read hook input from stdin (Claude Code passes JSON with session context)
+HOOK_INPUT=""
 if [ ! -t 0 ]; then
     HOOK_INPUT=$(cat)
+fi
+
+# Skip idle_prompt — user was already notified when input was first needed
+case "$HOOK_INPUT" in
+    *'"idle_prompt"'*)
+        exit 0
+        ;;
+esac
+
+# Skip non-Claude-Code hooks (e.g. Cursor's own AI fires Stop hooks with a
+# different JSON schema that uses conversation_id instead of session_id).
+# Claude Code always includes session_id in hook stdin.
+if [ -n "$HOOK_INPUT" ]; then
     case "$HOOK_INPUT" in
-        *'"idle_prompt"'*)
-            exit 0
-            ;;
+        *'"session_id"'*) ;;  # Claude Code session, continue
+        *) exit 0 ;;          # Not a Claude Code session, skip
     esac
 fi
 


### PR DESCRIPTION
## Problem

Cursor's built-in AI (chat, autocomplete, composer) fires Claude Code's `Stop` hook for every AI response, causing spurious "Task completed" notifications. This happens regardless of the model or mode used in Cursor.

## Root Cause

The `Stop` hook in `~/.claude/settings.json` has an empty matcher, so it fires for every Stop event from any process that reads that file. Cursor's internal AI engine shares the same settings file as Claude Code, so every Cursor AI response triggers a notification.

## Investigation

We added debug logging to `notify.sh` to capture the environment variables and stdin JSON for different scenarios:

| Source | `TERM_PROGRAM` | `TERM` | stdin JSON |
|---|---|---|---|
| iTerm2 (CLI) | `iTerm.app` | `xterm-256color` | `{"session_id":"...", ...}` |
| Cursor terminal panel | `vscode` | `xterm-256color` | `{"session_id":"...", ...}` |
| Claude Code extension (VS Code) | *(empty)* | `dumb` | `{"session_id":"...", ...}` |
| Claude Code extension (Cursor) | *(empty)* | `dumb` | `{"session_id":"...", ...}` |
| **Cursor's own AI** | *(empty)* | `dumb` | `{"conversation_id":"...", "cursor_version":"...", ...}` |

The key difference: Claude Code always includes `session_id` in the hook stdin JSON. Cursor's own AI uses a completely different schema with `conversation_id`/`generation_id` instead.

## Fix

After reading stdin, check for `session_id` in the JSON. If stdin has content but no `session_id`, it's not a Claude Code session and the script exits early.

This preserves notifications for all documented scenarios:
- Claude Code in any terminal (iTerm2, Terminal.app, Ghostty, Warp, etc.)
- Claude Code IDE extensions (VS Code, Cursor, Windsurf, VSCodium, WebStorm, IntelliJ)
- Claude Desktop's Code tab

Closes #42