### PR TITLE
feat: add Launch Services registration check to doctor

### DIFF
--- a/Sources/ClaudeNotifier/Constants.swift
+++ b/Sources/ClaudeNotifier/Constants.swift
@@ -12,4 +12,5 @@ enum Constants {
     static let terminalTypeKey = "terminalType"
     static let logFileName = "claude-notifier.log"
     static let configFileName = "config.json"
+    static let bundleIdentifier = "com.mlz11.claude-notifier"
 }

--- a/Sources/ClaudeNotifier/Doctor.swift
+++ b/Sources/ClaudeNotifier/Doctor.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 import Foundation
 import UserNotifications
 
@@ -27,6 +28,20 @@ func checkAppInstallation() -> CheckResult {
         passed: false,
         message: "ClaudeNotifier.app not found",
         remediation: "Install via 'brew install mlz11/tap/claude-notifier' or 'make install'"
+    )
+}
+
+func checkLaunchServicesRegistration() -> CheckResult {
+    let bundleId = Constants.bundleIdentifier as NSString
+    let cfResult = LSCopyApplicationURLsForBundleIdentifier(bundleId as CFString, nil)
+    if let urls = cfResult?.takeRetainedValue() as? [URL], !urls.isEmpty {
+        return CheckResult(passed: true, message: "Launch Services: app registered")
+    }
+
+    return CheckResult(
+        passed: false,
+        message: "Launch Services: app not registered with macOS",
+        remediation: "Run 'open /Applications/ClaudeNotifier.app' to register the app, or restart your Mac"
     )
 }
 
@@ -244,6 +259,7 @@ func runDoctor() {
     // Collect all check results
     let checks: [CheckResult] = [
         checkAppInstallation(),
+        checkLaunchServicesRegistration(),
         checkNotifyScript(),
         checkSettingsHooks(),
         checkNotificationPermissions()


### PR DESCRIPTION
## Summary
- Adds a Launch Services registration check to `claude-notifier doctor` that detects when the app is installed but not yet indexed by macOS
- Uses `LSCopyApplicationURLsForBundleIdentifier` to verify the app bundle is known to the system
- Provides clear remediation: `open /Applications/ClaudeNotifier.app` or restart

## Context
Addresses #41 where users installing via Homebrew see all-green doctor output but notifications silently fail until a system restart. The root cause is that macOS Launch Services hasn't registered the app bundle yet, so the notification subsystem doesn't recognize it.

## Test plan
- [ ] Build and run `claude-notifier doctor` to verify the new check appears and passes
- [ ] Verify lint passes (`make lint`)
- [ ] Simulate unregistered state by checking a fake bundle ID returns the failure path