### PR TITLE
feat: add `claude-notifier update` command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Sources/ClaudeNotifier/
 ├── ConfigCommand.swift  # Config command - interactive TUI for preferences
 ├── TUI.swift            # Raw terminal input + menu rendering for interactive config
 ├── Icon.swift           # Icon variant utilities (used by ConfigCommand and Doctor)
+├── Update.swift         # Update command + version check
 ├── ArgumentParser.swift # CLI flag parsing and help text
 └── Utilities.swift      # Helpers (exitWithError, terminateApp, focusTerminalSession)
 ```
@@ -65,7 +66,8 @@ Sources/ClaudeNotifier/
 - **ConfigCommand**: Interactive TUI for configuring icon color and notification sound
 - **TUI**: Raw terminal mode handling, arrow key navigation, and menu rendering
 - **Icon**: `IconVariant` enum, `getCurrentVariant()`, `setVariant()`, and helper functions for icon switching
-- **ArgumentParser**: Parses `-t`, `-s`, `-m`, `-i` flags and `setup`/`doctor`/`config`/`help` subcommands
+- **Update**: Version check via GitHub API, brew upgrade integration, doctor version check
+- **ArgumentParser**: Parses `-t`, `-s`, `-m`, `-i` flags and `setup`/`doctor`/`config`/`update`/`help` subcommands
 - **Utilities**: `exitWithError()`, `terminateApp()`, `focusTerminalSession()`, `TerminalType` enum
 
 **Entry flow:** Parse args → configure NSApplication → show notification (if -m provided) → handle notification click → focus terminal → exit
@@ -78,6 +80,7 @@ claude-notifier -m "Message" -i "$ITERM_SESSION_ID"  # With session ID for focus
 claude-notifier setup         # Auto-configure Claude Code hooks
 claude-notifier doctor        # Diagnose installation and permission issues
 claude-notifier config        # Configure preferences (icon, sound) interactively
+claude-notifier update        # Check for updates and upgrade via Homebrew
 ```
 
 ## Writing Style

--- a/README.md
+++ b/README.md
@@ -55,28 +55,6 @@ brew install --cask mlz11/tap/claude-notifier
 
 </details>
 
-<details>
-<summary><strong>From Source</strong></summary>
-
-```bash
-git clone https://github.com/mlz11/ClaudeNotifier.git
-cd ClaudeNotifier
-make install
-```
-
-You'll be prompted for the install directory (press Enter for default `/Applications`).
-
-This builds the app, installs it to the chosen directory, and creates a `claude-notifier` CLI command in `~/.local/bin`.
-
-If `~/.local/bin` is not in your PATH, add it:
-
-```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-```
-
-</details>
-
 ## 🚀 Usage
 
 ### Quick Setup for Claude Code

--- a/Sources/ClaudeNotifier/ArgumentParser.swift
+++ b/Sources/ClaudeNotifier/ArgumentParser.swift
@@ -28,6 +28,8 @@ func parseArguments() -> ParsedArguments {
             return .command("config")
         case "logs":
             return .command("logs")
+        case "update":
+            return .command("update")
         case "--request-automation":
             // Internal command: request automation permissions (launched via `open`)
             return .command("request-automation")
@@ -61,6 +63,7 @@ func showHelp() {
       doctor                      Diagnose installation and permission issues
       config                      Configure preferences interactively
       logs                        View the log file (--clear to truncate)
+      update                      Check for updates and upgrade via Homebrew
 
     Options:
       -m, --message "text"        The notification body (required for notifications)

--- a/Sources/ClaudeNotifier/Constants.swift
+++ b/Sources/ClaudeNotifier/Constants.swift
@@ -13,4 +13,6 @@ enum Constants {
     static let logFileName = "claude-notifier.log"
     static let configFileName = "config.json"
     static let bundleIdentifier = "com.mlz11.claude-notifier"
+    static let githubLatestReleaseURL = "https://api.github.com/repos/mlz11/ClaudeNotifier/releases/latest"
+    static let brewCaskName = "mlz11/tap/claude-notifier"
 }

--- a/Sources/ClaudeNotifier/Doctor.swift
+++ b/Sources/ClaudeNotifier/Doctor.swift
@@ -27,7 +27,7 @@ func checkAppInstallation() -> CheckResult {
     return CheckResult(
         passed: false,
         message: "ClaudeNotifier.app not found",
-        remediation: "Install via 'brew install mlz11/tap/claude-notifier' or 'make install'"
+        remediation: "Install via 'brew install mlz11/tap/claude-notifier'"
     )
 }
 
@@ -264,7 +264,8 @@ func runDoctor() {
         checkSettingsHooks(),
         checkNotificationPermissions()
     ] + checkTerminalAutomationPermissions() + [
-        checkPATHConfiguration()
+        checkPATHConfiguration(),
+        checkVersionUpToDate()
     ]
 
     // Problem-focused output

--- a/Sources/ClaudeNotifier/Icon.swift
+++ b/Sources/ClaudeNotifier/Icon.swift
@@ -58,7 +58,7 @@ func filesAreIdentical(_ file1: URL, _ file2: URL) -> Bool {
 func setVariant(_ variant: IconVariant) {
     guard let appPath = getInstalledAppPath() else {
         print(error("Error: ClaudeNotifier.app not found"))
-        print(warning("Install via 'brew install mlz11/tap/claude-notifier' or 'make install'"))
+        print(warning("Install via 'brew install mlz11/tap/claude-notifier'"))
         exit(1)
     }
 
@@ -70,7 +70,7 @@ func setVariant(_ variant: IconVariant) {
     guard FileManager.default.fileExists(atPath: variantPath.path) else {
         print(error("Error: Variant icon not found: \(variant.filename)"))
         print("The app may have been built without icon variants.")
-        print(warning("Run 'make icons && make install' to regenerate."))
+        print(warning("Reinstall via 'brew install --cask mlz11/tap/claude-notifier' to update icons."))
         exit(1)
     }
 

--- a/Sources/ClaudeNotifier/Update.swift
+++ b/Sources/ClaudeNotifier/Update.swift
@@ -48,6 +48,8 @@ func fetchLatestVersion() -> (tag: String, version: String)? {
 func isBrewInstall() -> Bool {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    // The cask token is "claude-notifier" (without tap prefix).
+    // brew list --cask resolves by token, not by full tap-qualified name.
     process.arguments = ["brew", "list", "--cask", "claude-notifier"]
     process.standardOutput = FileHandle.nullDevice
     process.standardError = FileHandle.nullDevice
@@ -79,9 +81,13 @@ func isBrewAvailable() -> Bool {
 
 // MARK: - Update Command
 
+// NOTE: fetchLatestVersion() uses DispatchSemaphore to block synchronously.
+// This is safe in CLI mode but would deadlock on the main thread of an NSApplication run loop.
+// The update and doctor commands call exit() before reaching app.run(), so this is fine.
+
 func runUpdate() {
     Logger.info("Running update check")
-    print("Checking for updates...")
+    print("Checking for updates...\(hint(" (this may take a moment)"))")
 
     guard let latest = fetchLatestVersion() else {
         print(error("Could not check for updates (network error or GitHub API unavailable)."))
@@ -126,12 +132,15 @@ func runUpdate() {
         process.waitUntilExit()
 
         if process.terminationStatus == 0 {
+            Logger.info("Update completed successfully")
             print(success("Updated successfully!"))
         } else {
+            Logger.error("Upgrade failed with exit code \(process.terminationStatus)")
             print(error("Upgrade failed (exit code \(process.terminationStatus))."))
             exit(1)
         }
     } catch let brewError {
+        Logger.error("Failed to run brew: \(brewError.localizedDescription)")
         print(error("Failed to run brew: \(brewError.localizedDescription)"))
         exit(1)
     }
@@ -141,7 +150,11 @@ func runUpdate() {
 
 func checkVersionUpToDate() -> CheckResult {
     guard let latest = fetchLatestVersion() else {
-        return CheckResult(passed: true, message: "Version: v\(Constants.version) (could not check for updates)")
+        return CheckResult(
+            passed: false,
+            message: "Version: v\(Constants.version) (could not check for updates)",
+            remediation: "Check your network connection or try again later"
+        )
     }
 
     let current = Constants.version

--- a/Sources/ClaudeNotifier/Update.swift
+++ b/Sources/ClaudeNotifier/Update.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// MARK: - Version Comparison
+
+func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+    let partsA = lhs.split(separator: ".").compactMap { Int($0) }
+    let partsB = rhs.split(separator: ".").compactMap { Int($0) }
+    let count = max(partsA.count, partsB.count)
+
+    for i in 0 ..< count {
+        let valA = i < partsA.count ? partsA[i] : 0
+        let valB = i < partsB.count ? partsB[i] : 0
+        if valA < valB { return .orderedAscending }
+        if valA > valB { return .orderedDescending }
+    }
+    return .orderedSame
+}
+
+// MARK: - GitHub API
+
+func fetchLatestVersion() -> (tag: String, version: String)? {
+    guard let url = URL(string: Constants.githubLatestReleaseURL) else { return nil }
+
+    var request = URLRequest(url: url)
+    request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
+    request.timeoutInterval = 10
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: (tag: String, version: String)?
+
+    URLSession.shared.dataTask(with: request) { data, _, _ in
+        defer { semaphore.signal() }
+        guard let data = data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tagName = json["tag_name"] as? String
+        else { return }
+
+        let version = tagName.hasPrefix("v") ? String(tagName.dropFirst()) : tagName
+        result = (tag: tagName, version: version)
+    }.resume()
+
+    semaphore.wait()
+    return result
+}
+
+// MARK: - Brew Detection
+
+func isBrewInstall() -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["brew", "list", "--cask", "claude-notifier"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    } catch {
+        return false
+    }
+}
+
+func isBrewAvailable() -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["brew", "--version"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    } catch {
+        return false
+    }
+}
+
+// MARK: - Update Command
+
+func runUpdate() {
+    Logger.info("Running update check")
+    print("Checking for updates...")
+
+    guard let latest = fetchLatestVersion() else {
+        print(error("Could not check for updates (network error or GitHub API unavailable)."))
+        exit(1)
+    }
+
+    let current = Constants.version
+    Logger.info("Current: \(current), Latest: \(latest.version)")
+
+    if compareVersions(current, latest.version) != .orderedAscending {
+        print(success("Already up to date") + " (v\(current))")
+        return
+    }
+
+    print("Update available: \(info("v\(current)")) → \(info("v\(latest.version)"))")
+
+    guard isBrewAvailable() else {
+        print(error("Homebrew is not installed."))
+        print("Install the update manually:")
+        print(
+            "  \(info("curl -fsSL https://raw.githubusercontent.com/mlz11/ClaudeNotifier/main/Scripts/install.sh | bash"))"
+        )
+        exit(1)
+    }
+
+    guard isBrewInstall() else {
+        print(warning("ClaudeNotifier was not installed via Homebrew."))
+        print("Reinstall via Homebrew to enable automatic updates:")
+        print("  \(info("brew install --cask \(Constants.brewCaskName)"))")
+        exit(1)
+    }
+
+    print("Upgrading via Homebrew...")
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["brew", "upgrade", "--cask", "claude-notifier"]
+    process.standardOutput = FileHandle.standardOutput
+    process.standardError = FileHandle.standardError
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus == 0 {
+            print(success("Updated successfully!"))
+        } else {
+            print(error("Upgrade failed (exit code \(process.terminationStatus))."))
+            exit(1)
+        }
+    } catch let brewError {
+        print(error("Failed to run brew: \(brewError.localizedDescription)"))
+        exit(1)
+    }
+}
+
+// MARK: - Doctor Integration
+
+func checkVersionUpToDate() -> CheckResult {
+    guard let latest = fetchLatestVersion() else {
+        return CheckResult(passed: true, message: "Version: v\(Constants.version) (could not check for updates)")
+    }
+
+    let current = Constants.version
+    if compareVersions(current, latest.version) != .orderedAscending {
+        return CheckResult(passed: true, message: "Version: v\(current) (latest)")
+    }
+
+    return CheckResult(
+        passed: false,
+        message: "Version: v\(current) (v\(latest.version) available)",
+        remediation: "Run 'claude-notifier update' to upgrade"
+    )
+}

--- a/Sources/ClaudeNotifier/main.swift
+++ b/Sources/ClaudeNotifier/main.swift
@@ -19,6 +19,9 @@ case "config":
 case "logs":
     runLogsCommand(args: CommandLine.arguments)
     exit(0)
+case "update":
+    runUpdate()
+    exit(0)
 case "request-automation":
     requestTerminalPermissions()
     exit(0)


### PR DESCRIPTION
## Summary

- Adds `claude-notifier update` command that checks GitHub for the latest release and upgrades via Homebrew (`brew upgrade --cask claude-notifier`)
- Adds version check to `claude-notifier doctor` output (network call placed last after local checks)
- Removes "From Source" (`make install`) as a documented install method in README
- Updates remediation text in Doctor and Icon to reference Homebrew instead of `make install`

Closes #49

## Test plan

- [x] `make build` compiles successfully
- [x] `claude-notifier update` checks GitHub and reports version status
- [x] `claude-notifier doctor` shows version check in output
- [x] `claude-notifier --help` shows update command
- [x] No remaining user-facing references to `make install` in source files